### PR TITLE
TypeError: Concatenating 'str' and 'error' objects in altdns.py

### DIFF
--- a/altdns.py
+++ b/altdns.py
@@ -203,7 +203,7 @@ def main():
                     t.daemon = True
                     t.start()
                 except Exception as error:
-                    print("error: " + error)
+                    print("error:"),(error)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Treat the error string and object type as separate entities, preventing the error "TypeError: Concatenating 'str' and 'error' objects."

Old:
root@0x3c:~/altdns# ./altdns.py -i test.txt -o data_output -w words.txt -r -s resolved_domains_big
[*] 500/626767 completed
[*] 1000/626767 completed
Traceback (most recent call last):
  File "./altdns.py", line 209, in <module>
    main()
  File "./altdns.py", line 206, in main
    print("error: " + error)
TypeError: cannot concatenate 'str' and 'error' objects


New:
root@0x3c:~/altdns# ./altdns.py -i test.txt -o data_output -w words.txt -r -s resolved_domains_big
[*] 500/626767 completed
[*] 1000/626767 completed
error: can't start new thread
error: can't start new thread
error: can't start new thread