### PR TITLE
Added -d flag to specify resolver to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ NOTE: Depends on `sort` (which is installed by default on unix).
 - the `-r` command resolves each generated, permuted subdomain
 - the `-s` command tells altdns where to save the results of the resolved permuted subdomains. `results_output.txt` will contain the final list of permuted subdomains found that are valid and have a DNS record.
 - the `-t` command limits how many threads the resolver will use simultaneously
+- `-d 1.2.3.4` overrides the system default resolver and will use `1.2.3.4` as the resolving server. Setting this to the authoritative DNS server of the target domain *may* increase performance 
 
 # Screenshots
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NOTE: Depends on `sort` (which is installed by default on unix).
 - the `-r` command resolves each generated, permuted subdomain
 - the `-s` command tells altdns where to save the results of the resolved permuted subdomains. `results_output.txt` will contain the final list of permuted subdomains found that are valid and have a DNS record.
 - the `-t` command limits how many threads the resolver will use simultaneously
-- `-d 1.2.3.4` overrides the system default resolver and will use `1.2.3.4` as the resolving server. Setting this to the authoritative DNS server of the target domain *may* increase performance 
+- `-d 1.2.3.4` overrides the system default DNS resolver and will use the specified IP address as the resolving server. Setting this to the authoritative DNS server of the target domain *may* increase resolution performance 
 
 # Screenshots
 

--- a/altdns.py
+++ b/altdns.py
@@ -344,7 +344,7 @@ def main():
                
         timetaken = str(datetime.timedelta(seconds=(int(time.time())-starttime)))
         print(
-            colored("[*] Completed in {1}".format(timetaken),
+            colored("[*] Completed in {0}".format(timetaken),
                     "blue"))
 
 if __name__ == "__main__":

--- a/altdns.py
+++ b/altdns.py
@@ -341,6 +341,11 @@ def main():
             #Wait for threads
             while len(threadhandler) > 0:
                threadhandler.pop().join()
+               
+        timetaken = str(datetime.timedelta(seconds=(int(time.time())-starttime)))
+        print(
+            colored("[*] Completed in {1}".format(timetaken),
+                    "blue"))
 
 if __name__ == "__main__":
     main()

--- a/altdns.py
+++ b/altdns.py
@@ -143,6 +143,7 @@ def get_cname(q, target, resolved_out):
     global lock
     global starttime
     global found
+    global resolverName
     lock.acquire()
     progress += 1
     lock.release()
@@ -159,14 +160,17 @@ def get_cname(q, target, resolved_out):
     final_hostname = target
     result = list()
     result.append(target)
+    resolver = dns.resolver.Resolver()
+    if(resolverName is not None): #if a DNS server has been manually specified
+        resolver.nameservers = [resolverName]
     try:
-      for rdata in dns.resolver.query(final_hostname, 'CNAME'):
+      for rdata in resolver.query(final_hostname, 'CNAME'):
         result.append(rdata.target)
     except:
         pass
     if len(result) is 1:
       try:
-        A = dns.resolver.Resolver().query(final_hostname, "A")
+        A = resolver.query(final_hostname, "A")
         if len(A) > 0:
           result = list()
           result.append(final_hostname)
@@ -186,7 +190,7 @@ def get_cname(q, target, resolved_out):
         ext = tldextract.extract(str(result[1]))
         if ext.domain == "amazonaws":
             try:
-                for rdata in dns.resolver.query(result[1], 'CNAME'):
+                for rdata in resolver.query(result[1], 'CNAME'):
                     result.append(rdata.target)
             except:
                 pass
@@ -257,6 +261,8 @@ def main():
     parser.add_argument("-e", "--ignore-existing",
                         help="Ignore existing domains in file",
                         action="store_true")
+    parser.add_argument("-d", "--dnsserver",
+                        help="IP address of resolver to use (overrides system default)", required=False)
 
     parser.add_argument(
         "-s",
@@ -309,11 +315,13 @@ def main():
         global lock
         global starttime
         global found
+        global resolverName       
         lock = Lock()
         found = {}
         progress = 0
         starttime = int(time.time())
         linecount = get_line_count(args.output)
+        resolverName = args.dnsserver
         with open(args.output, "r") as fp:
             for i in fp:
                 if args.threads:


### PR DESCRIPTION
I've tested this on a couple of VPS's, using the default resolver (which can have several hops between it and the authoritative DNS server of your target) vs querying the authoritative DNS server directly. On average I've seen about a 6x increase in performance.
`./altdns.py -i subdomains.txt -o data_output -w words.txt -r -s results.txt
[*] Completed in 0:06:57

./altdns.py -i subdomains.txt -o data_output -w words.txt -r -s results.txt -d X.X.X.X
[*] Completed in 0:01:07`

Also added some output to the end of the run that tells you the time it took to do the resolution